### PR TITLE
Improve initial app load time

### DIFF
--- a/services/docs_service/sync.py
+++ b/services/docs_service/sync.py
@@ -21,7 +21,7 @@ def get_title_from_path(path: str) -> str:
 def clone_or_pull_repo(repo_url: str, clone_path: Path):
     if not clone_path.exists():
         logger.info(f"cloning repository to {clone_path}")
-        subprocess.run(["git", "clone", repo_url, str(clone_path)], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        subprocess.run(["git", "clone", "--depth", "1", repo_url, str(clone_path)], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     else:
         logger.info(f"pulling latest changes in {clone_path}")
         subprocess.run(["git", "-C", str(clone_path), "pull"], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)


### PR DESCRIPTION
Did this by fetching only the latest commit from the repo. Else, the application setup takes too long if the repo isn't present locally